### PR TITLE
Render.items is initialized with empty list.

### DIFF
--- a/bubblepicker/src/main/java/com/igalata/bubblepicker/rendering/PickerRenderer.kt
+++ b/bubblepicker/src/main/java/com/igalata/bubblepicker/rendering/PickerRenderer.kt
@@ -34,7 +34,7 @@ class PickerRenderer(val glView: View) : GLSurfaceView.Renderer {
             Engine.radius = value
         }
     var listener: BubblePickerListener? = null
-    lateinit var items: ArrayList<PickerItem>
+    var items: ArrayList<PickerItem> = ArrayList()
 
     private var programId = 0
     private var verticesBuffer: FloatBuffer? = null


### PR DESCRIPTION
`lateinit` is a bad pattern. Let's you completely bypass null check on the non-null ArrayList.