### PR TITLE
Switch to `implementation`.

### DIFF
--- a/bubblepicker/build.gradle
+++ b/bubblepicker/build.gradle
@@ -33,11 +33,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    api "com.android.support:appcompat-v7:$supportLibVersion"
-    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    compile files('libs/jbox2d-library-2.1.2.2.jar')
-    compile files('libs/slf4j-api-1.7.22.jar')
+    implementation files('libs/jbox2d-library-2.1.2.2.jar')
+    implementation files('libs/slf4j-api-1.7.22.jar')
 }
 


### PR DESCRIPTION
No need to expose dependencies.