### PR TITLE
Fix bubble size

### DIFF
--- a/bubblepicker/src/main/java/com/igalata/bubblepicker/physics/Engine.kt
+++ b/bubblepicker/src/main/java/com/igalata/bubblepicker/physics/Engine.kt
@@ -17,10 +17,15 @@ object Engine : ContactListener {
     val selectedBodies: List<CircleBody>
         get() = bodies.filter { it.increased || it.toBeIncreased || it.isIncreasing }
     var maxSelectedCount: Int? = null
+
+    /**
+     * Represents what percentage of bigger screen dimension each bubble takes.
+     * Values 0..100 represent 15..35% of dimension
+     */
     var radius = 50
         set(value) {
             field = value
-            bubbleRadius = interpolate(0.1f, 0.25f, value / 100f)
+            bubbleRadius = interpolate(0.15f, 0.35f, value / 100f)
         }
     private var bubbleRadius = 0.15f
 
@@ -66,7 +71,7 @@ object Engine : ContactListener {
             val y = Random().nextFloat() - 0.5f
             val vx = (if (Random().nextBoolean()) -0.01f else 0.01f) * Random().nextFloat() / scaleY
             val vy = (if (Random().nextBoolean()) -0.01f else 0.01f) * Random().nextFloat() / scaleY
-            bodies.add(CircleBody(world, Vec2(x, y), bubbleRadius * scaleX, (bubbleRadius * scaleX) * 1.1f, density, Vec2(vx, vy)))
+            bodies.add(CircleBody(world, Vec2(x, y), bubbleRadius, bubbleRadius * 1.1f, density, Vec2(vx, vy)))
         }
         this.scaleX = scaleX
         this.scaleY = scaleY


### PR DESCRIPTION
Fixed bubble size. See comments below. Images below represent bubble pickers with exact same bubble radius, but different component dimensions (which resulted in big ass bubbles earlier)

![device-2021-01-18-134851](https://user-images.githubusercontent.com/70135181/104919193-24a9b400-5996-11eb-9ca4-90de1ab5b03b.png)
![device-2021-01-18-134923](https://user-images.githubusercontent.com/70135181/104919196-25424a80-5996-11eb-9ea2-d573f17ccb61.png)


![device-2021-01-18-134800](https://user-images.githubusercontent.com/70135181/104919181-21aec380-5996-11eb-916b-52524f0a02f1.png)