### PR TITLE
Fix item text gravity when selected

### DIFF
--- a/bubblepicker/src/main/java/com/igalata/bubblepicker/rendering/Item.kt
+++ b/bubblepicker/src/main/java/com/igalata/bubblepicker/rendering/Item.kt
@@ -111,7 +111,7 @@ data class Item(val context: Context, val pickerItem: PickerItem, val circleBody
 
         viewText.setMaxLines(1)
         viewText.setTextColor(if (isSelected) pickerItem.selectedTextColor!! else pickerItem.textColor!!)
-        viewIcon.setVisibility(if (isSelected) View.VISIBLE else View.GONE)
+        viewIcon.setVisibility(if (isSelected && pickerItem.icon != null) View.VISIBLE else View.GONE)
 
         measure()
         layout()


### PR DESCRIPTION
Due to discussion with Lukas and Rohan: https://scalablecapital.atlassian.net/browse/SMP-5418 I decided to fix that quickly, since I knew exactly what was a reason. 

Below photos before fix and after
![gravity_before](https://user-images.githubusercontent.com/70135181/105001344-e8c32d00-5a2f-11eb-84b0-5443f2b72ca6.png)
![gravity_after](https://user-images.githubusercontent.com/70135181/105001347-e9f45a00-5a2f-11eb-8860-8004a0b31e39.png)
