### PR TITLE
Bound bubble size to ratio of smaller dimension instead of bigger

### DIFF
--- a/bubblepicker/src/main/java/com/igalata/bubblepicker/physics/Engine.kt
+++ b/bubblepicker/src/main/java/com/igalata/bubblepicker/physics/Engine.kt
@@ -8,6 +8,8 @@ import org.jbox2d.common.Vec2
 import org.jbox2d.dynamics.World
 import org.jbox2d.dynamics.contacts.Contact
 import java.util.*
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Created by irinagalata on 1/26/17.
@@ -19,7 +21,7 @@ object Engine : ContactListener {
     var maxSelectedCount: Int? = null
 
     /**
-     * Represents what percentage of bigger screen dimension each bubble takes.
+     * Represents what percentage of smaller screen dimension each bubble takes.
      * Values 0..100 represent 15..35% of dimension
      */
     var radius = 50
@@ -66,12 +68,13 @@ object Engine : ContactListener {
 
     fun build(bodiesCount: Int, scaleX: Float, scaleY: Float): List<CircleBody> {
         val density = interpolate(0.8f, 0.2f, radius / 100f)
+        val scaleRatio = min(scaleX, scaleY) / max(scaleX, scaleY)
         for (i in 0..bodiesCount - 1) {
             val x = Random().nextFloat() - 0.5f
             val y = Random().nextFloat() - 0.5f
             val vx = (if (Random().nextBoolean()) -0.01f else 0.01f) * Random().nextFloat() / scaleY
             val vy = (if (Random().nextBoolean()) -0.01f else 0.01f) * Random().nextFloat() / scaleY
-            bodies.add(CircleBody(world, Vec2(x, y), bubbleRadius, bubbleRadius * 1.1f, density, Vec2(vx, vy)))
+            bodies.add(CircleBody(world, Vec2(x, y), bubbleRadius * scaleRatio, (bubbleRadius * scaleRatio) * 1.1f, density, Vec2(vx, vy)))
         }
         this.scaleX = scaleX
         this.scaleY = scaleY


### PR DESCRIPTION
I made the bubble size dependant on the smaller dimension, instead of bigger. This way if ratio height/width changes (but width of the view will remain the same), the bubble size will not change. Also thanks to the fact it's bound to smaller dimension, not explicitely width, rotation works just fine. 

I tested on:
3.3" 240x440 mdpi
5.96" 1440x2560 560dpi
OnePlus emulator
Samsung S9+ emulator


With previous implementation: 
![Screenshot 2021-02-04 at 14 40 11](https://user-images.githubusercontent.com/70135181/106901297-dadffe00-66f7-11eb-8493-5b337e355279.png)

With new implementation:
![Screenshot 2021-02-04 at 14 38 08](https://user-images.githubusercontent.com/70135181/106901315-e2070c00-66f7-11eb-8b40-6a42c5c5d0db.png)
